### PR TITLE
Fix chaining with empty diffs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,8 +60,11 @@ pub fn parse<'a>() -> Result<(String, Vec<Patch<'a>>, Params), ParseError> {
 
     let contents_ref: &'a str = Box::leak(contents.into_boxed_str());
 
-    let patches =
-        Patch::from_multiple(contents_ref).map_err(|e| ParseError::Patch(e.to_string()))?;
+    let patches = if contents_ref.trim().is_empty() {
+        Vec::new()
+    } else {
+        Patch::from_multiple(contents_ref).map_err(|e| ParseError::Patch(e.to_string()))?
+    };
 
     let params = Params {
         grep: cli.grep,


### PR DESCRIPTION
## Summary
- prevent parse errors when grephunk receives no patch input

## Testing
- `cargo run -- -V`
- `printf "" | cargo run -- -v foo`

------
https://chatgpt.com/codex/tasks/task_e_684410823ef0832c9c0e81e5bc391296